### PR TITLE
fix subscriber default `max_subscriber_count`

### DIFF
--- a/lib/commanded/event_store/adapters/extreme/subscription.ex
+++ b/lib/commanded/event_store/adapters/extreme/subscription.ex
@@ -301,7 +301,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Subscription do
            stream,
            name,
            %Spear.PersistentSubscription.Settings{
-             max_subscriber_count: concurrency_limit
+             max_subscriber_count: 0
            },
            from: from
          ) do


### PR DESCRIPTION
For some reason persistent subscription connections are not dropped on the esdb side when they are dropped on the client side. This leads to new connections failing since esdb thinks/says the dropped connection is still connected.

If the limit is increased esdb will collect "dead" connections until the limit is reached so we need to say that there is no limit. Then esdb manages to clean up dead connections.